### PR TITLE
feat: refactor GraphQL schema generation to support multi-tenant architecture

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -1,46 +1,53 @@
 // src/factory.ts
 
-import { createGraphQLType } from './graphql/types';
-import { createGraphQLInputType } from './graphql/inputs';
 import { generateQueries } from './graphql/queries';
 import { generateMutations } from './graphql/mutations';
 import { generateSubscriptions } from './graphql/subscriptions';
 import { GraphQLObjectType, GraphQLSchema } from 'graphql';
 import { registerMetadata } from './metadata/registry';
+import { SchemaKey, toSchemaKeyString } from './metadata/schemaKey';
 import { Metadata } from './metadata/types';
 import { validateMetadata } from './metadata/validators';
 import { getLogger } from './utils/logger';
 import { getTracer } from './utils/tracing';
-import { wrapSpan } from './utils/wrapSpan';
 
-export async function createGraphQLSchema(name: string, metadata: Metadata): Promise<GraphQLSchema> {
+
+export async function createGraphQLSchema(
+    name: string,
+    metadata: Metadata,
+    tenantId: string,
+    clientApp: string
+): Promise<GraphQLSchema> {
     const logger = getLogger();
+    const tracer = getTracer();
 
-    return await wrapSpan(`schema.createGraphQLSchema.${name}`, async () => {
+    return await tracer.startSpan(`schema.createGraphQLSchema.${name}`, async () => {
         validateMetadata(name, metadata);
-        registerMetadata(name, metadata);
+
+        const key: SchemaKey = { name, tenantId, clientApp };
+        registerMetadata(key, metadata);
 
         const QueryType = new GraphQLObjectType({
             name: `${name}_Query`,
-            fields: () => generateQueries(name, metadata)
+            fields: () => generateQueries(key, metadata)
         });
 
         const MutationType = new GraphQLObjectType({
             name: `${name}_Mutation`,
-            fields: () => generateMutations(name, metadata)
+            fields: () => generateMutations(key, metadata)
         });
 
         const SubscriptionType = new GraphQLObjectType({
             name: `${name}_Subscription`,
-            fields: () => generateSubscriptions(name, metadata)
+            fields: () => generateSubscriptions(key, metadata)
         });
 
-        logger.info(`GraphQL schema created for ${name}`);
+        logger.info(`GraphQL schema created for`, key);
 
         return new GraphQLSchema({
             query: QueryType,
             mutation: MutationType,
             subscription: SubscriptionType
-        })
-    });
+        });
+    })
 }

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -1,60 +1,59 @@
 // src/graphql/queries.ts
 
-import { GraphQLFieldConfigMap, GraphQLID, GraphQLList, GraphQLNonNull } from 'graphql'
-import { pluralize } from '../utils/pluralize'
-import { createGraphQLType } from './types'
-import { Metadata } from '../metadata/types'
-import { getLogger } from '../utils/logger'
-import { getTracer } from '../utils/tracing'
-import { requireScope } from '../utils/requireScope'
+import { GraphQLFieldConfigMap, GraphQLID, GraphQLList, GraphQLNonNull } from 'graphql';
+import { createGraphQLType } from './types';
+import { Metadata } from '../metadata/types';
+import { getLogger } from '../utils/logger';
+import { getTracer } from '../utils/tracing';
+import { SchemaKey } from '../metadata/schemaKey';
+import { requireScope } from '../utils/requireScope';
 
-export function generateQueries(name: string, metadata: Metadata): GraphQLFieldConfigMap<any, any> {
-    const logger = getLogger()
-    const tracer = getTracer()
-    const type = createGraphQLType(name, metadata)
+export function generateQueries(key: SchemaKey, metadata: Metadata): GraphQLFieldConfigMap<any, any> {
+    const logger = getLogger();
+    const tracer = getTracer();
+    const type = createGraphQLType(key, metadata);
 
     return {
-        [`find${name}ById`]: {
+        [`find${key.name}ById`]: {
             type,
             args: {
                 id: { type: new GraphQLNonNull(GraphQLID) }
             },
             resolve: async (_, args, context) => {
-                requireScope(context, `${name.toLowerCase()}:read`)
-                return await tracer.startSpan(`query.${name}.findById`, async () => {
-                    const db = context.mongo.db()
-                    const collection = db.collection(pluralize(name.toLowerCase()))
+                requireScope(context, `${key.name.toLowerCase()}:read`)
+                return await tracer.startSpan(`query.${key.name}.findById`, async () => {
+                    const db = context.mongo.db();
+                    const collection = db.collection(`${key.name.toLowerCase()}s`);
 
-                    const filter: Record<string, any> = { _id: args.id }
-
+                    const filter: Record<string, any> = { _id: args.id };
                     if (metadata.tenantScoped && context.tenantId) {
-                        filter.tenantId = context.tenantId
+                        filter.tenantId = context.tenantId;
                     }
 
-                    const result = await collection.findOne(filter)
-                    logger.info(`Fetched ${name} by ID`, { id: args.id })
-                    return result
+                    const result = await collection.findOne(filter);
+                    logger.info(`Fetched ${key.name} by ID`, { id: args.id });
+                    return result;
                 })
             }
         },
-        [`find${name}`]: {
+        [`find${key.name}`]: {
             type: new GraphQLList(type),
             resolve: async (_, __, context) => {
-                requireScope(context, `${name.toLowerCase()}:read`)
-                return await tracer.startSpan(`query.${name}.findAll`, async () => {
-                    const db = context.mongo.db()
-                    const collection = db.collection(pluralize(name.toLowerCase()))
+                requireScope(context, `${key.name.toLowerCase()}:read`)
+                return await tracer.startSpan(`query.${key.name}.findAll`, async () => {
+                    const db = context.mongo.db();
+                    const collection = db.collection(`${key.name.toLowerCase()}s`);
 
-                    const filter: Record<string, any> = {}
+                    const filter: Record<string, any> = {};
                     if (metadata.tenantScoped && context.tenantId) {
-                        filter.tenantId = context.tenantId
+                        filter.tenantId = context.tenantId;
                     }
 
-                    const results = await collection.find(filter).toArray()
-                    logger.info(`Fetched all ${name}`, { count: results.length })
-                    return results
+                    const results = await collection.find(filter).toArray();
+                    logger.info(`Fetched all ${key.name}`, { count: results.length });
+                    return results;
                 })
             }
         }
-    }
+    };
 }

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -1,14 +1,29 @@
 // src/graphql/resolvers.ts
 
-import { generateQueries } from './queries'
-import { generateMutations } from './mutations'
-import { generateSubscriptions } from './subscriptions'
-import { Metadata } from '../metadata/types'
+import { GraphQLObjectType } from 'graphql';
+import { generateQueries } from './queries';
+import { generateMutations } from './mutations';
+import { generateSubscriptions } from './subscriptions';
+import { Metadata } from '../metadata/types';
+import { SchemaKey } from '../metadata/schemaKey';
 
-export function generateResolvers(name: string, metadata: Metadata) {
+export function createResolvers(key: SchemaKey, metadata: Metadata): {
+    query: GraphQLObjectType
+    mutation: GraphQLObjectType
+    subscription: GraphQLObjectType
+} {
     return {
-        Query: generateQueries(name, metadata),
-        Mutation: generateMutations(name, metadata),
-        Subscription: generateSubscriptions(name, metadata)
-    }
+        query: new GraphQLObjectType({
+            name: `${key.name}_Query`,
+            fields: () => generateQueries(key, metadata)
+        }),
+        mutation: new GraphQLObjectType({
+            name: `${key.name}_Mutation`,
+            fields: () => generateMutations(key, metadata)
+        }),
+        subscription: new GraphQLObjectType({
+            name: `${key.name}_Subscription`,
+            fields: () => generateSubscriptions(key, metadata)
+        })
+    };
 }

--- a/src/graphql/subscriptions.ts
+++ b/src/graphql/subscriptions.ts
@@ -1,53 +1,55 @@
 // src/graphql/subscriptions.ts
 
-import { GraphQLFieldConfigMap } from 'graphql'
-import { createGraphQLType } from './types'
-import { getMetadata } from '../metadata/registry'
-import { pubsub } from '../pubsub'
-import { getLogger } from '../utils/logger'
-import { requireScope } from '../utils/requireScope'
-import { Metadata } from '../metadata/types'
+import { GraphQLFieldConfigMap } from 'graphql';
+import { createGraphQLType } from './types';
+import { pubsub } from '../pubsub';
+import { getLogger } from '../utils/logger';
+import { getTracer } from '../utils/tracing';
+import { requireScope } from '../utils/requireScope';
+import { SchemaKey } from '../metadata/schemaKey';
+import { Metadata } from '../metadata/types';
 
-export function generateSubscriptions(name: string, metadata: Metadata): GraphQLFieldConfigMap<any, any> {
-    const logger = getLogger()
-    const type = createGraphQLType(name, metadata)
-    const fields: GraphQLFieldConfigMap<any, any> = {}
+export function generateSubscriptions(key: SchemaKey, metadata: Metadata): GraphQLFieldConfigMap<any, any> {
+    const logger = getLogger();
+    const tracer = getTracer();
+    const type = createGraphQLType(key, metadata);
+    const fields: GraphQLFieldConfigMap<any, any> = {};
 
     if (metadata.subscriptions?.onCreated) {
-        fields[`on${name}Created`] = {
+        fields[`on${key.name}Created`] = {
             type,
             subscribe: (_, __, context) => {
-                requireScope(context, `${name.toLowerCase()}:subscribe`)
-                logger.info(`Subscribed: on${name}Created`)
-                return pubsub.asyncIterableIterator(`${name}_CREATED`)
+                requireScope(context, `${key.name.toLowerCase()}:subscribe`);
+                logger.info(`Subscribed: on${key.name}Created`);
+                return pubsub.asyncIterableIterator(`${key.name}_CREATED`);
             },
             resolve: (payload: any) => payload
         }
     }
 
     if (metadata.subscriptions?.onUpdated) {
-        fields[`on${name}Updated`] = {
+        fields[`on${key.name}Updated`] = {
             type,
             subscribe: (_, __, context) => {
-                requireScope(context, `${name.toLowerCase()}:subscribe`)
-                logger.info(`Subscribed: on${name}Updated`)
-                return pubsub.asyncIterableIterator(`${name}_UPDATED`)
+                requireScope(context, `${key.name.toLowerCase()}:subscribe`);
+                logger.info(`Subscribed: on${key.name}Updated`);
+                return pubsub.asyncIterableIterator(`${key.name}_UPDATED`);
             },
             resolve: (payload: any) => payload
         }
     }
 
     if (metadata.subscriptions?.onDeleted) {
-        fields[`on${name}Deleted`] = {
+        fields[`on${key.name}Deleted`] = {
             type,
             subscribe: (_, __, context) => {
-                requireScope(context, `${name.toLowerCase()}:subscribe`)
-                logger.info(`Subscribed: on${name}Deleted`)
-                return pubsub.asyncIterableIterator(`${name}_DELETED`)
+                requireScope(context, `${key.name.toLowerCase()}:subscribe`);
+                logger.info(`Subscribed: on${key.name}Deleted`);
+                return pubsub.asyncIterableIterator(`${key.name}_DELETED`);
             },
             resolve: (payload: any) => payload
         }
     }
 
-    return fields
+    return fields;
 }

--- a/src/graphql/typeRegistry.ts
+++ b/src/graphql/typeRegistry.ts
@@ -1,0 +1,35 @@
+// src/graphql/typeRegistry.ts
+
+import { getLogger } from '../utils/logger';
+
+import { GraphQLObjectType, GraphQLInputObjectType } from 'graphql';
+import { SchemaKey, toSchemaKeyString } from '../metadata/schemaKey';
+
+const objectTypeRegistry = new Map<string, GraphQLObjectType>();
+const inputTypeRegistry = new Map<string, GraphQLInputObjectType>();
+const logger = getLogger();
+
+export function registerObjectType(key: SchemaKey, type: GraphQLObjectType) {
+    logger.info('Registered GraphQLObjectType', key);
+    objectTypeRegistry.set(toSchemaKeyString(key), type);
+}
+
+export function getObjectType(key: SchemaKey): GraphQLObjectType | undefined {
+    return objectTypeRegistry.get(toSchemaKeyString(key));
+}
+
+export function registerInputType(key: SchemaKey, inputType: GraphQLInputObjectType) {
+    logger.info('Registered GraphQLInputObjectType', key);
+    inputTypeRegistry.set(toSchemaKeyString(key), inputType);
+}
+
+export function getInputType(key: SchemaKey): GraphQLInputObjectType | undefined {
+    return inputTypeRegistry.get(toSchemaKeyString(key));
+}
+
+export function clearTypeCache(key: SchemaKey) {
+    logger.info('Clearing GraphQLObjectType from cache', key);
+    objectTypeRegistry.delete(toSchemaKeyString(key));
+    logger.info('Clearing GraphQLInputObjectType from cache', key);
+    inputTypeRegistry.delete(toSchemaKeyString(key));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,28 +1,31 @@
 // src/index.ts
 
-import { getLogger, useLogger, ConsoleLogger } from './utils/logger'
-import { getTracer, useTracer, NoopTracer } from './utils/tracing'
+import { useLogger, ConsoleLogger } from './utils/logger';
+import { useTracer, NoopTracer } from './utils/tracing';
 
 // Auto-wire default logger and tracer
-useLogger(ConsoleLogger)
-useTracer(NoopTracer)
+useLogger(ConsoleLogger);
+useTracer(NoopTracer);
 
-export * from './factory'
-export * from './metadata/types'
-export * from './metadata/registry'
-export * from './metadata/validators'
-export * from './mongo/context'
-export * from './mongo/connectMongo'
-export * from './mongo/utils'
-export * from './graphql/types'
-export * from './graphql/queries'
-export * from './graphql/mutations'
-export * from './graphql/subscriptions'
-export * from './graphql/inputs'
-export * from './graphql/resolvers'
-export * from './pubsub'
-export * from './utils/logger'
-export * from './utils/tracing'
-export * from './utils/requireScope'
-export * from './utils/pluralize'
-export * from './lib/authContext'
+export * from './factory';
+export * from './metadata/types';
+export * from './metadata/registry';
+export * from './metadata/validators';
+export * from './mongo/context';
+export * from './mongo/connectMongo';
+export * from './mongo/utils';
+export * from './graphql/types';
+export * from './graphql/queries';
+export * from './graphql/mutations';
+export * from './graphql/subscriptions';
+export * from './graphql/inputs';
+export * from './graphql/resolvers';
+export * from './pubsub';
+export * from './utils/logger';
+export * from './utils/tracing';
+export * from './utils/requireScope';
+export * from './utils/pluralize';
+export * from './lib/authContext';
+
+export { clearTypeCache } from './graphql/typeRegistry';
+export { registerSchemaRoutes } from './routes/schema';

--- a/src/metadata/registry.ts
+++ b/src/metadata/registry.ts
@@ -1,22 +1,22 @@
 // src/metadata/registry.ts
 
-import { Metadata } from './types'
-import { getLogger } from '../utils/logger'
+import { Metadata } from './types';
+import { SchemaKey, toSchemaKeyString } from './schemaKey';
+import { getLogger } from '../utils/logger';
 
-const schemaRegistry: Record<string, Metadata> = {}
+const logger = getLogger();
+const metadataRegistry = new Map<string, Metadata>();
 
-export function registerMetadata(name: string, metadata: Metadata): void {
-    const logger = getLogger()
-    logger.info(`Registering metadata for schema: ${name}`)
-    schemaRegistry[name] = metadata
+export function registerMetadata(key: SchemaKey, metadata: Metadata): void {
+    logger.info('Registered schema metadata', key);
+    metadataRegistry.set(toSchemaKeyString(key), metadata);
 }
 
-export function getMetadata(name: string): Metadata {
-    const schema = schemaRegistry[name]
-    if (!schema) {
-        const logger = getLogger()
-        logger.error(`No metadata registered for schema '${name}'`)
-        throw new Error(`No metadata registered for schema '${name}'`)
-    }
-    return schema
+export function getMetadata(key: SchemaKey): Metadata | undefined {
+    return metadataRegistry.get(toSchemaKeyString(key));
+}
+
+export function clearMetadata(key: SchemaKey): void {
+    logger.info('Cleared schema metadata', key);
+    metadataRegistry.delete(toSchemaKeyString(key));
 }

--- a/src/metadata/schemaKey.ts
+++ b/src/metadata/schemaKey.ts
@@ -1,0 +1,11 @@
+// src/metadata/schemaKey.ts
+
+export interface SchemaKey {
+    name: string
+    tenantId: string
+    clientApp: string
+}
+
+export function toSchemaKeyString({ name, tenantId, clientApp }: SchemaKey): string {
+    return JSON.stringify({ name, tenantId, clientApp });
+}

--- a/src/metadata/validators.ts
+++ b/src/metadata/validators.ts
@@ -1,21 +1,21 @@
 // src/metadata/validators.ts
 
-import { Metadata, FieldType } from './types'
-import { getLogger } from '../utils/logger'
+import { Metadata, FieldType } from './types';
+import { getLogger } from '../utils/logger';
 
 const allowedTypes: FieldType[] = [
     'string', 'text', 'number', 'boolean', 'datetime', 'uuid', 'json'
-]
+];
 
 export function validateMetadata(name: string, metadata: Metadata): void {
-    const logger = getLogger()
+    const logger = getLogger();
 
     for (const [field, def] of Object.entries(metadata.fields)) {
         if (!allowedTypes.includes(def.type)) {
-            logger.error(`Invalid type '${def.type}' for field '${field}' in schema '${name}'`)
-            throw new Error(`Invalid type '${def.type}' for field '${field}' in schema '${name}'`)
+            logger.error(`Invalid type '${def.type}' for field '${field}' in schema '${name}'`);
+            throw new Error(`Invalid type '${def.type}' for field '${field}' in schema '${name}'`);
         }
     }
 
-    logger.info(`Metadata validation passed for schema '${name}'`)
+    logger.info(`Metadata validation passed for schema '${name}'`);
 }

--- a/src/mongo/connectMongo.ts
+++ b/src/mongo/connectMongo.ts
@@ -1,23 +1,23 @@
 // src/mongo/connectMongo.ts
 
-import { MongoClient } from 'mongodb'
-import { getLogger } from '../utils/logger'
+import { MongoClient } from 'mongodb';
+import { getLogger } from '../utils/logger';
 
-let client: MongoClient | null = null
+let client: MongoClient | null = null;
 
 export async function connectMongo(uri: string): Promise<MongoClient> {
-    const logger = getLogger()
+    const logger = getLogger();
 
     if (!client) {
-        client = new MongoClient(uri)
-        await client.connect()
-        logger.info('[MongoDB] Connected', { uri })
+        client = new MongoClient(uri);
+        await client.connect();
+        logger.info('[MongoDB] Connected', { uri });
     }
 
-    return client
+    return client;
 }
 
 export function getMongoClient(): MongoClient {
-    if (!client) throw new Error('MongoDB client not initialized')
-    return client
+    if (!client) throw new Error('MongoDB client not initialized');
+    return client;
 }

--- a/src/mongo/context.ts
+++ b/src/mongo/context.ts
@@ -1,7 +1,7 @@
 // src/mongo/context.ts
 
-import { MongoClient } from 'mongodb'
-import { getLogger } from '../utils/logger'
+import { MongoClient } from 'mongodb';
+import { getLogger } from '../utils/logger';
 
 export interface RequestContext {
     mongo: MongoClient
@@ -10,16 +10,16 @@ export interface RequestContext {
 }
 
 export async function createContext(mongo: MongoClient, req: any): Promise<RequestContext> {
-    const logger = getLogger()
-    const user = req.user || null
-    const tenantId = req.headers['x-tenant-id'] || undefined
+    const logger = getLogger();
+    const user = req.user || null;
+    const tenantId = req.headers['x-tenant-id'] || undefined;
 
-    if (user) logger.info('Context initialized with user', { userId: user.id })
-    if (tenantId) logger.info('Context initialized with tenant', { tenantId })
+    if (user) logger.info('Context initialized with user', { userId: user.id });
+    if (tenantId) logger.info('Context initialized with tenant', { tenantId });
 
     return {
         mongo,
         user,
         tenantId
-    }
+    };
 }

--- a/src/mongo/utils.ts
+++ b/src/mongo/utils.ts
@@ -1,26 +1,26 @@
 // src/mongo/utils.ts
 
-import { getLogger } from '../utils/logger'
-import { getTracer } from '../utils/tracing'
+import { getLogger } from '../utils/logger';
+import { getTracer } from '../utils/tracing';
 
 export function toMongoFilter(filter: Record<string, any>) {
-    const logger = getLogger()
-    const tracer = getTracer()
+    const logger = getLogger();
+    const tracer = getTracer();
 
     return tracer.startSpan('utils.toMongoFilter', async () => {
-        logger.debug?.('Building MongoDB filter', { filter })
+        logger.debug?.('Building MongoDB filter', { filter });
         // TODO: Add support for more advanced filters ($gt, $in, etc.)
         for (const key in filter) {
             if (typeof filter[key] === 'object' && filter[key] !== null) {
-            for (const operator in filter[key]) {
-                if (['$gt', '$gte', '$lt', '$lte', '$in', '$nin', '$ne'].includes(operator)) {
-                filter[key] = { ...filter[key] }
-                } else {
-                throw new Error(`Unsupported operator: ${operator}`)
+                for (const operator in filter[key]) {
+                    if (['$gt', '$gte', '$lt', '$lte', '$in', '$nin', '$ne'].includes(operator)) {
+                        filter[key] = { ...filter[key] };
+                    } else {
+                        throw new Error(`Unsupported operator: ${operator}`)
+                    }
                 }
             }
-            }
         }
-        return filter
-    })
+        return filter;
+    });
 }

--- a/src/pubsub/adapters/memory.ts
+++ b/src/pubsub/adapters/memory.ts
@@ -1,9 +1,9 @@
 // src/pubsub/adapters/memory.ts
 
-import { PubSub } from 'graphql-subscriptions'
-import { getLogger } from '../../utils/logger'
+import { PubSub } from 'graphql-subscriptions';
+import { getLogger } from '../../utils/logger';
 
-const logger = getLogger()
-logger.info('Using in-memory PubSub adapter')
+const logger = getLogger();
+logger.info('Using in-memory PubSub adapter');
 
-export const memoryPubSub = new PubSub()
+export const memoryPubSub = new PubSub();

--- a/src/pubsub/index.ts
+++ b/src/pubsub/index.ts
@@ -1,10 +1,10 @@
 // src/pubsub/index.ts
 
-import { memoryPubSub } from './adapters/memory'
-import { getLogger } from '../utils/logger'
+import { memoryPubSub } from './adapters/memory';
+import { getLogger } from '../utils/logger';
 
 // Eventually, support runtime selection (e.g., Redis)
-const logger = getLogger()
-logger.info('PubSub initialized with memory adapter')
+const logger = getLogger();
+logger.info('PubSub initialized with memory adapter');
 
-export const pubsub = memoryPubSub
+export const pubsub = memoryPubSub;

--- a/src/routes/schema.ts
+++ b/src/routes/schema.ts
@@ -1,0 +1,58 @@
+// src/routes/schema.ts
+
+import { FastifyInstance } from 'fastify';
+import { MongoClient } from 'mongodb';
+import { getLogger } from '../utils/logger';
+import { validateMetadata } from '../metadata/validators';
+import { authContext } from '../lib/authContext';
+import { createGraphQLSchema } from '../factory';
+import { Metadata } from '../metadata/types';
+
+export async function registerSchemaRoutes(app: FastifyInstance, mongo: MongoClient) {
+    const logger = getLogger();
+
+    app.post('/admin/schema', async (req, reply) => {
+        const { name, metadata, clientApp } = req.body as {
+            name: string;
+            metadata: Metadata;
+            clientApp: string;
+        };
+        validateMetadata(name, metadata);
+
+        const { tenantId } = await authContext(req, mongo);
+
+        if (!name || !metadata || !tenantId || !clientApp) {
+            return reply.status(400).send({ error: 'Missing required fields: name, metadata, clientApp' })
+        }
+
+        const db = mongo.db('wize-configuration')
+        const filter = { name, tenantId, clientApp }
+
+        try {
+            await db.collection('schemas').updateOne(
+                filter,
+                {
+                    $set: {
+                        name,
+                        tenantId,
+                        clientApp,
+                        metadata,
+                        updatedAt: new Date()
+                    }
+                },
+                { upsert: true }
+            );
+
+            await createGraphQLSchema(name, metadata, tenantId, clientApp);
+            logger.info(`Schema registered successfully`, { name, tenantId, clientApp });
+
+            return reply.status(200).send({ message: 'Schema registered successfully' });
+        } catch (err) {
+            logger.error(err as Error)
+            return reply.status(500).send({
+                error: 'Failed to register schema',
+                details: err instanceof Error ? err.message : String(err)
+            });
+        }
+    })
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -14,12 +14,12 @@ export const ConsoleLogger: ILogger = {
     debug: (msg, meta) => console.debug('[DEBUG]', msg, meta)
 }
 
-let activeLogger: ILogger = ConsoleLogger
+let activeLogger: ILogger = ConsoleLogger;
 
 export function useLogger(logger: ILogger) {
-    activeLogger = logger
+    activeLogger = logger;
 }
 
 export function getLogger(): ILogger {
-    return activeLogger
+    return activeLogger;
 }

--- a/src/utils/pluralize.ts
+++ b/src/utils/pluralize.ts
@@ -2,10 +2,10 @@
 
 export function pluralize(word: string): string {
     if (word.endsWith('y') && !/[aeiou]y$/i.test(word)) {
-        return word.slice(0, -1) + 'ies'
+        return word.slice(0, -1) + 'ies';
     }
     if (word.endsWith('s')) {
-        return word + 'es'
+        return word + 'es';
     }
-    return word + 's'
+    return word + 's';
 }

--- a/src/utils/tracing.ts
+++ b/src/utils/tracing.ts
@@ -6,16 +6,16 @@ export interface ITracer {
 
 export const NoopTracer: ITracer = {
     startSpan(name, fn) {
-        return fn()
+        return fn();
     }
 }
 
 let activeTracer: ITracer = NoopTracer
 
 export function useTracer(tracer: ITracer) {
-    activeTracer = tracer
+    activeTracer = tracer;
 }
 
 export function getTracer(): ITracer {
-    return activeTracer
+    return activeTracer;
 }

--- a/src/utils/wrapSpan.ts
+++ b/src/utils/wrapSpan.ts
@@ -1,9 +1,9 @@
 // src/utils/wrapSpan.ts
 
-import { getTracer } from './tracing'
+import { getTracer } from './tracing';
 
 export async function wrapSpan<T>(name: string, fn: () => T | Promise<T>): Promise<T> {
-    const tracer = getTracer()
-    const result = await tracer.startSpan(name, fn)
-    return result
+    const tracer = getTracer();
+    const result = await tracer.startSpan(name, fn);
+    return result;
 }


### PR DESCRIPTION
- Updated createGraphQLSchema to accept tenantId and clientApp parameters.
- Modified generateQueries, generateMutations, and generateSubscriptions to use SchemaKey for better metadata handling.
- Introduced type caching for GraphQLObjectType and GraphQLInputObjectType to optimize performance.
- Added new schemaKey utility for managing schema identifiers.
- Implemented schema registration routes for dynamic schema management.
- Enhanced logging for better traceability during schema operations.