### PR TITLE
feat: Implement context and schema creation for GraphQL API with API key validation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,3 +31,6 @@ export * from './lib/authContext';
 
 export { clearTypeCache } from './graphql/typeRegistry';
 export { registerSchemaRoutes } from './routes/schema';
+
+export * from './server/context';
+export * from './server/schema';

--- a/src/metadata/validators.ts
+++ b/src/metadata/validators.ts
@@ -17,5 +17,5 @@ export function validateMetadata(name: string, metadata: Metadata): void {
         }
     }
 
-    logger.info(`Metadata validation passed for schema '${name}'`);
+    logger.info(`Metadata validation passed for schema '${name}'`)
 }

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -1,7 +1,7 @@
 import { MongoClient } from 'mongodb';
 import { createFactoryAuthContext } from '../lib/authContext';
 
-export const createContext = async (request: Request, mongo: MongoClient) => {
+export const createServerContext = async (request: Request, mongo: MongoClient) => {
     const apiKey = request.headers.get('wize-api-key');
     if (!apiKey) throw new Error('Missing Wize API key');
     return createFactoryAuthContext(mongo, apiKey);

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -1,0 +1,8 @@
+import { MongoClient } from 'mongodb';
+import { createFactoryAuthContext } from '../lib/authContext';
+
+export const createContext = async (request: Request, mongo: MongoClient) => {
+    const apiKey = request.headers.get('wize-api-key');
+    if (!apiKey) throw new Error('Missing Wize API key');
+    return createFactoryAuthContext(mongo, apiKey);
+};

--- a/src/server/schema.ts
+++ b/src/server/schema.ts
@@ -4,7 +4,7 @@ import { createFactoryAuthContext } from '../lib/authContext';
 import { loadSchemasFromMongo } from '../utils/loadSchemas';
 import { buildMergedSchema } from '../schema/merge';
 
-export const createSchema = async (request: Request, mongo: MongoClient) => {
+export const createServerSchema = async (request: Request, mongo: MongoClient) => {
     const apiKey = request.headers.get('wize-api-key');
     if (!apiKey) throw new Error('Missing Wize API key');
 

--- a/src/server/schema.ts
+++ b/src/server/schema.ts
@@ -1,0 +1,35 @@
+import { GraphQLObjectType, GraphQLSchema, GraphQLString } from 'graphql';
+import { MongoClient } from 'mongodb';
+import { createFactoryAuthContext } from '../lib/authContext';
+import { loadSchemasFromMongo } from '../utils/loadSchemas';
+import { buildMergedSchema } from '../schema/merge';
+
+export const createSchema = async (request: Request, mongo: MongoClient) => {
+    const apiKey = request.headers.get('wize-api-key');
+    if (!apiKey) throw new Error('Missing Wize API key');
+
+    const ctx = await createFactoryAuthContext(mongo, apiKey);
+    const schemas = await loadSchemasFromMongo(mongo, ctx.tenantId, ctx.clientApp);
+
+    if (schemas.length === 0) {
+        return new GraphQLSchema({
+            query: new GraphQLObjectType({
+                name: 'Query',
+                fields: {
+                    _empty: {
+                        type: GraphQLString,
+                        resolve: () => 'No schemas available for this key.'
+                    }
+                }
+            })
+        });
+    }
+
+    return buildMergedSchema(
+        schemas.map((s) => ({
+            ...s,
+            tenantId: ctx.tenantId,
+            clientApp: ctx.clientApp
+        }))
+    );
+};


### PR DESCRIPTION
Introduce `createServerContext` and `createServerSchema` functions to enhance the GraphQL API, ensuring API key validation for secure access. Rename existing functions for improved clarity.