### PR TITLE
feat: Add systemReserved field to metadata and enforce its usage for protected fields

### DIFF
--- a/src/graphql/types.ts
+++ b/src/graphql/types.ts
@@ -24,6 +24,10 @@ export function createGraphQLType(key: SchemaKey, metadata: Metadata): GraphQLOb
     }
 
     const fields = Object.entries(metadata.fields).reduce((acc: Record<string, any>, [fieldName, fieldDef]) => {
+        if (fieldDef.systemReserved) {
+            return acc
+        }
+
         acc[fieldName] = { type: resolveGraphQLType(fieldDef, fieldName, key) }
         return acc
     }, {})

--- a/src/metadata/enforcement.ts
+++ b/src/metadata/enforcement.ts
@@ -1,0 +1,13 @@
+import { Metadata } from './types'
+
+export function enforceSystemFields(metadata: Metadata): Metadata {
+    const protectedFields = ['tenantId']
+
+    for (const fieldName of protectedFields) {
+        if (metadata.fields[fieldName]) {
+            metadata.fields[fieldName].systemReserved = true
+        }
+    }
+
+    return metadata
+}

--- a/src/metadata/types.ts
+++ b/src/metadata/types.ts
@@ -22,6 +22,8 @@ export interface FieldDefinition {
     defaultValue?: any;
     description?: string;
     relation?: RelationDefinition;
+    enum?: string[];
+    systemReserved?: boolean;
 }
 
 export interface Metadata {

--- a/src/server/schema.ts
+++ b/src/server/schema.ts
@@ -3,6 +3,7 @@ import { MongoClient } from 'mongodb';
 import { createAuthContext } from './authContext';
 import { loadSchemasFromMongo } from '../utils/loadSchemas';
 import { buildMergedSchema } from '../schema/merge';
+import { enforceSystemFields } from '../metadata/enforcement';
 
 export const createServerSchema = async (request: any, mongo: MongoClient) => {
     
@@ -11,7 +12,7 @@ export const createServerSchema = async (request: any, mongo: MongoClient) => {
 
     const ctx = await createAuthContext(mongo, apiKey);
     const schemas = await loadSchemasFromMongo(mongo, ctx.tenantId, ctx.clientApp);
-
+    
     if (schemas.length === 0) {
         return new GraphQLSchema({
             query: new GraphQLObjectType({
@@ -29,6 +30,7 @@ export const createServerSchema = async (request: any, mongo: MongoClient) => {
     return buildMergedSchema(
         schemas.map((s) => ({
             ...s,
+            metadata: enforceSystemFields(s.metadata),
             tenantId: ctx.tenantId,
             clientApp: ctx.clientApp
         }))


### PR DESCRIPTION
Introduce a systemReserved field in metadata to mark protected fields, ensuring that these fields are not processed in certain operations. Implement enforcement of this field for specific protected fields like tenantId.